### PR TITLE
Hotfix to reimplement version injection in github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,12 +107,6 @@ jobs:
           name: helm-chart
           path: helm
 
-      - name: Print file contents
-        run: | 
-          ls
-          ls helm
-          cat helm/Chart.yaml
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Extract version from github ref
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -85,6 +88,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            IMAGE_VERSION=${{ env.RELEASE_VERSION }}
 
   helm-publish:
     needs:


### PR DESCRIPTION
- Fixes an issue introduced by [v0.4.6](https://github.com/danielemery/quizlord-api/releases/tag/v0.4.6) (https://github.com/danielemery/quizlord-api/pull/44) where `IMAGE_VERSION` was not being provided at docker container build time
- Tested at https://stg.quizlord.net/ with version `v0.4.7-48-fix-version-injection.0`