### PR TITLE
Add filtering options to the quiz list resolver to include only incomplete quizzes

### DIFF
--- a/src/gql.ts
+++ b/src/gql.ts
@@ -110,8 +110,28 @@ const typeDefs = gql`
     completion: QuizCompletion
   }
 
+  "Available filters for the quizzes query"
+  input QuizFilters {
+    """
+    Optional list of user emails.
+    If provided, only quizzes completed by none of these users will be included in the results.
+    """
+    excludeCompletedBy: [String]
+  }
+
   type Query {
-    quizzes(first: Int, after: String): QuizConnection
+    """
+    Get a paged list of quizzes.
+    Optionally filter using the filters parameter.
+    """
+    quizzes(
+      "The number of results to return, capped at 100"
+      first: Int
+      "The cursor to start returning results from, for pagination"
+      after: String
+      "The filters to apply to the query"
+      filters: QuizFilters
+    ): QuizConnection
     quiz(id: String!): QuizDetails
     users(first: Int, after: String): UserConnection
     me: UserDetails

--- a/src/models.ts
+++ b/src/models.ts
@@ -31,6 +31,10 @@ export interface QuizDetails {
   completions: QuizCompletion[];
 }
 
+export interface QuizFilters {
+  excludeCompletedBy?: string[];
+}
+
 export interface User {
   email: string;
   name?: string;

--- a/src/resolvers/quizResolvers.ts
+++ b/src/resolvers/quizResolvers.ts
@@ -10,7 +10,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 import { QuizlordContext } from '..';
-import { Quiz, QuizDetails, QuizCompletion, QuizImage, CreateQuizResult } from '../models';
+import { Quiz, QuizDetails, QuizCompletion, QuizImage, CreateQuizResult, QuizFilters } from '../models';
 import { persistence } from '../persistence/persistence';
 import { createKey, generateSignedUploadUrl, keyToUrl } from '../s3';
 import { base64Decode, base64Encode, PagedResult, requireUserRole } from './helpers';
@@ -69,7 +69,7 @@ function quizPersistenceWithMyCompletionsToQuiz(
 
 export async function quizzes(
   _: unknown,
-  { first = 100, after }: { first: number; after?: string },
+  { first = 100, after, filters = {} }: { first: number; after?: string; filters: QuizFilters },
   context: QuizlordContext,
 ): Promise<PagedResult<Quiz>> {
   requireUserRole(context, 'USER');
@@ -78,6 +78,7 @@ export async function quizzes(
     userEmail: context.email,
     afterId,
     limit: first,
+    filters,
   });
   const edges = data.map((quiz) => ({
     node: quizPersistenceWithMyCompletionsToQuiz(quiz),


### PR DESCRIPTION
- Allows filtering quizzes by not completed by **any** of the provided list of emails