### PR TITLE
Sort users by the number of quizzes you have completed with them

### DIFF
--- a/src/gql.ts
+++ b/src/gql.ts
@@ -24,6 +24,12 @@ const typeDefs = gql`
     QUESTION_AND_ANSWER
   }
 
+  enum UserSortOption {
+    EMAIL_ASC
+    NAME_ASC
+    NUMBER_OF_QUIZZES_COMPLETED_WITH_DESC
+  }
+
   type PageInfo {
     hasNextPage: Boolean
     startCursor: String
@@ -133,7 +139,10 @@ const typeDefs = gql`
       filters: QuizFilters
     ): QuizConnection
     quiz(id: String!): QuizDetails
-    users(first: Int, after: String): UserConnection
+    """
+    Get a paged list of users.
+    """
+    users(first: Int, after: String, sortedBy: UserSortOption): UserConnection
     me: UserDetails
   }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -54,3 +54,5 @@ export interface CreateQuizResult {
     link: string;
   }[];
 }
+
+export type UserSortOption = 'EMAIL_ASC' | 'NAME_ASC' | 'NUMBER_OF_QUIZZES_COMPLETED_WITH_DESC';

--- a/src/resolvers/userResolvers.ts
+++ b/src/resolvers/userResolvers.ts
@@ -1,7 +1,7 @@
 import { User as UserPersistence } from '@prisma/client';
 
 import { QuizlordContext } from '..';
-import { User, UserDetails } from '../models';
+import { User, UserDetails, UserSortOption } from '../models';
 import { persistence } from '../persistence/persistence';
 import { base64Decode, base64Encode, PagedResult, requireUserRole } from './helpers';
 
@@ -14,7 +14,11 @@ function userPersistenceToUser(user: UserPersistence): User {
 
 export async function users(
   _: unknown,
-  { first = 100, after }: { first: number; after?: string },
+  {
+    first = 100,
+    after,
+    sortedBy = 'NUMBER_OF_QUIZZES_COMPLETED_WITH_DESC',
+  }: { first: number; after?: string; sortedBy: UserSortOption },
   context: QuizlordContext,
 ): Promise<PagedResult<User>> {
   requireUserRole(context, 'USER');
@@ -23,6 +27,8 @@ export async function users(
     role: 'USER',
     afterId,
     limit: first,
+    sortedBy,
+    currentUserId: context.userId,
   });
   const edges = data.map((user) => ({
     node: userPersistenceToUser(user),


### PR DESCRIPTION
Unfortunately Prisma doesn't support this kind of complex query.
I'm a bit wary of shifting complexity into an SQL query like this one. It makes the code quite a bit less approachable.

Another option I've considered is a more eventually consistent approach where a periodic job computes the quizzes completed with each other user and stores it in something like redis. But since we currently have no worker or redis setup I thought that would blow the scope of this work out completely.