### PR TITLE
Improve test coverage & fix exposed issues

### DIFF
--- a/src/auth/authentication.service.ts
+++ b/src/auth/authentication.service.ts
@@ -1,20 +1,18 @@
 import jwt, { JwtHeader, SigningKeyCallback, VerifyOptions } from 'jsonwebtoken';
 import jwksClient, { RsaSigningKey } from 'jwks-rsa';
 
-import config from '../config/config';
-
 export class AuthenticationService {
   #client: jwksClient.JwksClient;
   #options: VerifyOptions;
 
-  constructor() {
+  constructor(auth0Domain: string, auth0Audience: string) {
     this.#client = jwksClient({
-      jwksUri: `https://${config.AUTH0_DOMAIN}/.well-known/jwks.json`,
+      jwksUri: `https://${auth0Domain}/.well-known/jwks.json`,
     });
     this.#options = {
       algorithms: ['RS256'],
-      audience: config.AUTH0_AUDIENCE,
-      issuer: `https://${config.AUTH0_DOMAIN}/`,
+      audience: auth0Audience,
+      issuer: `https://${auth0Domain}/`,
     };
   }
 

--- a/src/auth/authorisation.errors.ts
+++ b/src/auth/authorisation.errors.ts
@@ -1,0 +1,1 @@
+export class UnauthorisedError extends Error {}

--- a/src/auth/authorisation.service.test.ts
+++ b/src/auth/authorisation.service.test.ts
@@ -1,4 +1,5 @@
 import { QuizlordContext } from '..';
+import { UnauthorisedError } from './authorisation.errors';
 import { AuthorisationService } from './authorisation.service';
 
 describe('authorisation', () => {
@@ -15,7 +16,7 @@ describe('authorisation', () => {
         const context = {
           roles: ['USER'],
         } as QuizlordContext;
-        expect(() => sut.requireUserRole(context, 'ADMIN')).toThrow('You are not authorised to perform this action');
+        expect(() => sut.requireUserRole(context, 'ADMIN')).toThrow(UnauthorisedError);
       });
     });
   });

--- a/src/auth/authorisation.service.test.ts
+++ b/src/auth/authorisation.service.test.ts
@@ -1,0 +1,22 @@
+import { QuizlordContext } from '..';
+import { AuthorisationService } from './authorisation.service';
+
+describe('authorisation', () => {
+  describe('authorisation.service', () => {
+    const sut = new AuthorisationService();
+    describe('requireUserRole', () => {
+      it('must do nothing if the user has the required role', () => {
+        const context = {
+          roles: ['USER', 'ADMIN'],
+        } as QuizlordContext;
+        sut.requireUserRole(context, 'ADMIN');
+      });
+      it('must throw an error if the user does not have the required role', () => {
+        const context = {
+          roles: ['USER'],
+        } as QuizlordContext;
+        expect(() => sut.requireUserRole(context, 'ADMIN')).toThrow('You are not authorised to perform this action');
+      });
+    });
+  });
+});

--- a/src/auth/authorisation.service.ts
+++ b/src/auth/authorisation.service.ts
@@ -1,10 +1,11 @@
 import { Role } from '@prisma/client';
 import { QuizlordContext } from '..';
+import { UnauthorisedError } from './authorisation.errors';
 
 export class AuthorisationService {
   requireUserRole(context: QuizlordContext, role: Role) {
     if (!context.roles.includes(role)) {
-      throw new Error('You are not authorised to perform this action');
+      throw new UnauthorisedError('You are not authorised to perform this action');
     }
   }
 }

--- a/src/quiz/quiz.errors.ts
+++ b/src/quiz/quiz.errors.ts
@@ -1,0 +1,1 @@
+export class MustProvideAtLeastOneFileError extends Error {}

--- a/src/quiz/quiz.gql.ts
+++ b/src/quiz/quiz.gql.ts
@@ -37,13 +37,10 @@ async function createQuiz(
   context: QuizlordContext,
 ): Promise<CreateQuizResult> {
   authorisationService.requireUserRole(context, 'USER');
-  return quizService.createQuiz({
+  return quizService.createQuiz(context.userId, {
     type,
     date,
     files,
-    userId: context.userId,
-    email: context.email,
-    userName: context.userName,
   });
 }
 

--- a/src/quiz/quiz.service.test.ts
+++ b/src/quiz/quiz.service.test.ts
@@ -4,8 +4,9 @@ import { S3FileService } from '../file/s3.service';
 import { Decimal } from '@prisma/client/runtime/library';
 
 const mockPersistence = {
-  getQuizzesWithUserResults: jest.fn(),
   getCompletionScoreWithQuizTypesForUser: jest.fn(),
+  getQuizzesWithUserResults: jest.fn(),
+  getQuizByIdWithResults: jest.fn(),
 };
 const mockFileService = {};
 
@@ -177,6 +178,39 @@ describe('quiz', () => {
         expect(actual).toEqual({
           stats: [0.5, 0.25],
           cursor: '2',
+        });
+      });
+    });
+    describe('getQuizDetails', () => {
+      it('must call getQuizByIdWithResults on persistence with correct arguments and transform the result', async () => {
+        mockPersistence.getQuizByIdWithResults.mockResolvedValueOnce({
+          id: 'fake-quiz-id',
+          type: 'SHARK',
+          date: new Date('2023-01-01'),
+          uploadedAt: new Date('2023-01-02'),
+          completions: [],
+          images: [],
+          uploadedByUser: {
+            id: 'fake-user-id',
+            email: 'master@quizlord.net',
+            name: 'Master',
+          },
+        });
+
+        const actual = await sut.getQuizDetails('fake-quiz-id');
+
+        expect(actual).toEqual({
+          id: 'fake-quiz-id',
+          type: 'SHARK',
+          date: new Date('2023-01-01'),
+          uploadedAt: new Date('2023-01-02'),
+          completions: [],
+          images: [],
+          uploadedBy: {
+            id: 'fake-user-id',
+            email: 'master@quizlord.net',
+            name: 'Master',
+          },
         });
       });
     });

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -60,6 +60,8 @@ export class QuizService {
     const quiz = await this.#persistence.getQuizByIdWithResults({
       id,
     });
+    // TODO look into modifying the upstream https://eslint.org/docs/latest/rules/no-unused-vars#ignorerestsiblings linting rule
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { images, completions, uploadedByUser, uploadedByUserId, ...quizFieldsThatDoNotRequireTransform } = quiz;
     return {
       ...quizFieldsThatDoNotRequireTransform,

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -47,11 +47,16 @@ export class QuizService {
     return { data: data.map((entry) => this.#quizPersistenceWithMyCompletionsToQuiz(entry)), hasMoreRows };
   }
 
+  /**
+   * Get a quiz along with all its completions and images.
+   * @param id Id of the quiz to get details for.
+   * @returns The quiz and its completions.
+   */
   async getQuizDetails(id: string) {
     const quiz = await this.#persistence.getQuizByIdWithResults({
       id,
     });
-    const { images, completions, uploadedByUser, ...quizFieldsThatDoNotRequireTransform } = quiz;
+    const { images, completions, uploadedByUser, uploadedByUserId, ...quizFieldsThatDoNotRequireTransform } = quiz;
     return {
       ...quizFieldsThatDoNotRequireTransform,
       completions: completions.map((entry) => this.#quizCompletionPersistenceToQuizCompletion(entry)),

--- a/src/service.locator.ts
+++ b/src/service.locator.ts
@@ -15,7 +15,7 @@ import config from './config/config';
 const memoryCache = new MemoryCache();
 
 // auth
-export const authenticationService = new AuthenticationService();
+export const authenticationService = new AuthenticationService(config.AUTH0_DOMAIN, config.AUTH0_AUDIENCE);
 export const authorisationService = new AuthorisationService();
 
 // prisma

--- a/src/service.locator.ts
+++ b/src/service.locator.ts
@@ -24,13 +24,13 @@ export const prismaService = new PrismaService();
 // file
 export const fileService = new S3FileService(config.AWS_REGION, config.AWS_BUCKET_NAME, config.FILE_ACCESS_BASE_URL);
 
-// quiz
-export const quizPersistence = new QuizPersistence(prismaService);
-export const quizService = new QuizService(quizPersistence, fileService);
-
 // user
 export const userPersistence = new UserPersistence(prismaService);
 export const userService = new UserService(userPersistence);
+
+// quiz
+export const quizPersistence = new QuizPersistence(prismaService);
+export const quizService = new QuizService(quizPersistence, fileService, userService);
 
 // queue
 export const queueService = new SQSQueueService(quizService);

--- a/src/statistics/statistics.service.test.ts
+++ b/src/statistics/statistics.service.test.ts
@@ -130,18 +130,8 @@ describe('statistics', () => {
         const actual = await sut.getIndividualUserStatistics();
 
         expect(mockUserService.getUsers).toHaveBeenCalledTimes(2);
-        expect(mockUserService.getUsers).toHaveBeenNthCalledWith(1, {
-          currentUserId: '1',
-          first: 100,
-          afterId: undefined,
-          sortedBy: 'EMAIL_ASC',
-        });
-        expect(mockUserService.getUsers).toHaveBeenNthCalledWith(2, {
-          currentUserId: '1',
-          first: 100,
-          afterId: '75',
-          sortedBy: 'EMAIL_ASC',
-        });
+        expect(mockUserService.getUsers).toHaveBeenNthCalledWith(1, 100, 'EMAIL_ASC', undefined);
+        expect(mockUserService.getUsers).toHaveBeenNthCalledWith(2, 100, 'EMAIL_ASC', '75');
 
         expect(mockGetStatisticsForUser).toHaveBeenCalledTimes(3);
         expect(mockGetStatisticsForUser).toHaveBeenNthCalledWith(1, 'userOne@quizlord.net');

--- a/src/statistics/statistics.service.test.ts
+++ b/src/statistics/statistics.service.test.ts
@@ -46,7 +46,7 @@ describe('statistics', () => {
         const actual = await sut.getIndividualUserStatistics();
 
         expect(mockCache.getItem).toHaveBeenCalledTimes(1);
-        expect(mockCache.getItem).toHaveBeenCalledWith('invidual-user-statistics');
+        expect(mockCache.getItem).toHaveBeenCalledWith('individual-user-statistics');
 
         expect(mockSortIndividualUserStatistics).toHaveBeenCalledTimes(1);
         expect(mockSortIndividualUserStatistics).toHaveBeenCalledWith(
@@ -150,6 +150,9 @@ describe('statistics', () => {
 
         expect(mockSortIndividualUserStatistics).toHaveBeenCalledTimes(1);
         expect(mockSortIndividualUserStatistics).toHaveBeenCalledWith(expected, 'QUIZZES_COMPLETED_DESC');
+
+        expect(mockCache.setItem).toHaveBeenCalledTimes(1);
+        expect(mockCache.setItem).toHaveBeenCalledWith('individual-user-statistics', expected, 24 * 60 * 60 * 1000);
 
         expect(actual).toEqual(expected);
       });

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -1,5 +1,5 @@
 import { QuizService } from '../quiz/quiz.service';
-import { UserService } from '../user/user.service';
+import { GetUsersResult, UserService } from '../user/user.service';
 import { Cache } from '../util/cache';
 import { IndividualUserStatistic, IndividualUserStatisticsSortOption } from './statistics.dto';
 
@@ -35,12 +35,8 @@ export class StatisticsService {
     let hasMoreRows = true;
     let cursor: string | undefined = undefined;
     while (hasMoreRows) {
-      const { data, hasMoreRows: moreRows } = await this.#userService.getUsers({
-        currentUserId: '1', // Current user id isn't valid here and isn't used for sorting by EMAIL_ASC
-        first: 100,
-        afterId: cursor,
-        sortedBy: 'EMAIL_ASC',
-      });
+      const userPage: GetUsersResult = await this.#userService.getUsers(100, 'EMAIL_ASC', cursor);
+      const { data, hasMoreRows: moreRows } = userPage;
 
       for (const user of data) {
         const { totalQuizCompletions, averageScorePercentage } = await this.getStatisticsForUser(user.email);

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -3,8 +3,8 @@ import { UserService } from '../user/user.service';
 import { Cache } from '../util/cache';
 import { IndividualUserStatistic, IndividualUserStatisticsSortOption } from './statistics.dto';
 
-const INDIVIDUAL_STATISTICS_CACHE_KEY = 'invidual-user-statistics';
-const INDIVIDUAL_STATISTICS_CACHE_TTL = 60 * 60 * 1000; // 24 hours
+const INDIVIDUAL_STATISTICS_CACHE_KEY = 'individual-user-statistics';
+const INDIVIDUAL_STATISTICS_CACHE_TTL_MILLIS = 24 * 60 * 60 * 1000; // 24 hours
 
 export class StatisticsService {
   #userService: UserService;
@@ -56,7 +56,7 @@ export class StatisticsService {
       hasMoreRows = moreRows;
     }
 
-    await this.#cache.setItem(INDIVIDUAL_STATISTICS_CACHE_KEY, results, INDIVIDUAL_STATISTICS_CACHE_TTL);
+    await this.#cache.setItem(INDIVIDUAL_STATISTICS_CACHE_KEY, results, INDIVIDUAL_STATISTICS_CACHE_TTL_MILLIS);
     return this.sortIndividualUserStatistics(results, sortedBy);
   }
 

--- a/src/user/user.errors.ts
+++ b/src/user/user.errors.ts
@@ -1,0 +1,1 @@
+export class UserNotFoundError extends Error {}

--- a/src/user/user.persistence.ts
+++ b/src/user/user.persistence.ts
@@ -4,6 +4,15 @@ import { PrismaService } from '../database/prisma.service';
 import { UserSortOption } from '../user/user.dto';
 import { getPagedQuery, slicePagedResults } from '../util/paging-helpers';
 
+export interface GetUsersWithRoleResult {
+  data: {
+    id: string;
+    email: string;
+    name: string | null;
+  }[];
+  hasMoreRows: boolean;
+}
+
 export class UserPersistence {
   #prisma: PrismaService;
   constructor(prisma: PrismaService) {
@@ -56,19 +65,30 @@ export class UserPersistence {
     return roles.map((r) => r.role);
   }
 
+  /**
+   * Get a list of users with the given role sorted by the provided option.
+   * @param arguments Query parameters.
+   * @returns A list of users with the given role and flag indicating if there are more.
+   */
   async getUsersWithRole({
     role,
     afterId,
     limit,
     sortedBy,
-    currentUserId,
   }: {
+    /** Only users with this role will be returned. */
     role: Role;
+    /** If provided, will be used as a cursor. */
     afterId?: string;
+    /** The number of users to load. */
     limit: number;
-    sortedBy: UserSortOption;
-    currentUserId: string;
-  }) {
+    /**
+     * The sorting option to use.
+     * Note if you want to sort by NUMBER_OF_QUIZZES_COMPLETED_WITH_DESC please see
+     * getUsersWithRoleSortedByNumberOfQuizzesCompletedWith.
+     */
+    sortedBy: Omit<UserSortOption, 'NUMBER_OF_QUIZZES_COMPLETED_WITH_DESC'>;
+  }): Promise<GetUsersWithRoleResult> {
     const pagedWhereQuery = {
       ...getPagedQuery(limit, afterId),
       where: {
@@ -83,6 +103,7 @@ export class UserPersistence {
     let result;
     switch (sortedBy) {
       case 'EMAIL_ASC':
+      default:
         result = await this.#prisma.client().user.findMany({
           ...pagedWhereQuery,
           orderBy: {
@@ -98,26 +119,51 @@ export class UserPersistence {
           },
         });
         break;
-      case 'NUMBER_OF_QUIZZES_COMPLETED_WITH_DESC':
-      default:
-        /**
-         * Prisma does not yet support ordering by a relation with anything other than count.
-         * We need to do something quite a bit more complex.
-         */
-        result = (await this.#prisma.client().$queryRaw`
-select id, email, name from 
-  (
-    select "user".*, count(my_completion.user_id) as completions from "user"
-    left outer join quiz_completion_user as their_completion on "user".id = their_completion.user_id
-    left outer join quiz_completion on their_completion.quiz_completion_id = quiz_completion.id
-    left outer join quiz_completion_user as my_completion on my_completion.quiz_completion_id = quiz_completion.id and my_completion.user_id = ${currentUserId}
-    group by "user".id
-  ) as completions_with_current_user
-order by completions_with_current_user.completions desc;
-        `) as User[];
-        break;
     }
 
+    return slicePagedResults(result, limit, afterId !== undefined);
+  }
+
+  /**
+   * Special variant of getUsersWithRole which sorts by the number of quizzes completed with the provided user.
+   *
+   * Note this was split out from getUsersWithRole because it requires dropping down to a raw query and has the
+   * additional requirement of the current user's id.
+   *
+   * @param arguments Query parameters.
+   * @returns List of users with the given role, sorted by the number of quizzes completed with provided user.
+   */
+  async getUsersWithRoleSortedByNumberOfQuizzesCompletedWith({
+    role,
+    afterId,
+    limit,
+    currentUserId,
+  }: {
+    /** Only users with this role will be returned. */
+    role: Role;
+    /** Optional user id to use as a cursor. */
+    afterId?: string;
+    /** The number of users to load. */
+    limit: number;
+    /** The id of the user to use to sort. */
+    currentUserId: string;
+  }): Promise<GetUsersWithRoleResult> {
+    /**
+     * Prisma does not yet support ordering by a relation with anything other than count.
+     * We need to do something quite a bit more complex so we drop down to a raw query.
+     */
+    const result = (await this.#prisma.client().$queryRaw`
+  select id, email, name from 
+    (
+      select "user".*, count(my_completion.user_id) as completions from "user"
+      inner join user_role on "user".id = user_role.user_id and user_role.role::text = ${role}
+      left outer join quiz_completion_user as their_completion on "user".id = their_completion.user_id
+      left outer join quiz_completion on their_completion.quiz_completion_id = quiz_completion.id
+      left outer join quiz_completion_user as my_completion on my_completion.quiz_completion_id = quiz_completion.id and my_completion.user_id = ${currentUserId}
+      group by "user".id
+    ) as completions_with_current_user
+  order by completions_with_current_user.completions desc;
+          `) as User[];
     return slicePagedResults(result, limit, afterId !== undefined);
   }
 }

--- a/src/user/user.persistence.ts
+++ b/src/user/user.persistence.ts
@@ -30,6 +30,14 @@ export class UserPersistence {
     });
   }
 
+  async getUserById(id: string) {
+    return this.#prisma.client().user.findFirst({
+      where: {
+        id,
+      },
+    });
+  }
+
   async createNewUser(id: string, email: string, name: string | undefined) {
     await this.#prisma.client().user.create({
       data: {

--- a/src/user/user.service.test.ts
+++ b/src/user/user.service.test.ts
@@ -1,0 +1,107 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import { UserPersistence } from './user.persistence';
+import { UserService } from './user.service';
+
+jest.mock('uuid');
+
+const mockedUUIDv4 = jest.mocked(uuidv4);
+const fakeUserPersistence = {
+  getUserByEmail: jest.fn(),
+  createNewUser: jest.fn(),
+  updateUserName: jest.fn(),
+};
+
+describe('user', () => {
+  describe('user.service', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
+    const sut = new UserService(fakeUserPersistence as unknown as UserPersistence);
+    describe('loadUserDetailsAndUpdateIfNecessary', () => {
+      it('must return existing user with roles if it exists already with correct name', async () => {
+        fakeUserPersistence.getUserByEmail.mockResolvedValueOnce({
+          id: 'fake-id',
+          name: 'Joe Blogs',
+          roles: [{ role: 'ADMIN' }],
+        });
+
+        const actual = await sut.loadUserDetailsAndUpdateIfNecessary('joe@quizlord.net', 'Joe Blogs');
+
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledWith('joe@quizlord.net');
+
+        expect(fakeUserPersistence.createNewUser).not.toHaveBeenCalled();
+        expect(fakeUserPersistence.updateUserName).not.toHaveBeenCalled();
+
+        expect(actual).toEqual({
+          id: 'fake-id',
+          roles: ['ADMIN'],
+        });
+      });
+      it('must create the user if it does not exist', async () => {
+        fakeUserPersistence.getUserByEmail.mockResolvedValueOnce(undefined);
+        mockedUUIDv4.mockReturnValueOnce('fake-id');
+
+        const actual = await sut.loadUserDetailsAndUpdateIfNecessary('joe@quizlord.net', 'Joe Blogs');
+
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledWith('joe@quizlord.net');
+
+        expect(fakeUserPersistence.createNewUser).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.createNewUser).toHaveBeenCalledWith('fake-id', 'joe@quizlord.net', 'Joe Blogs');
+
+        expect(fakeUserPersistence.updateUserName).not.toHaveBeenCalled();
+
+        expect(actual).toEqual({
+          id: 'fake-id',
+          roles: [],
+        });
+      });
+      it('must update the name if it is different', async () => {
+        fakeUserPersistence.getUserByEmail.mockResolvedValueOnce({
+          id: 'fake-id',
+          name: 'Joe Biggs',
+          roles: [{ role: 'ADMIN' }],
+        });
+
+        const actual = await sut.loadUserDetailsAndUpdateIfNecessary('joe@quizlord.net', 'Joe Blogs');
+
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledWith('joe@quizlord.net');
+
+        expect(fakeUserPersistence.createNewUser).not.toHaveBeenCalled();
+
+        expect(fakeUserPersistence.updateUserName).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.updateUserName).toHaveBeenCalledWith('fake-id', 'Joe Blogs');
+
+        expect(actual).toEqual({
+          id: 'fake-id',
+          roles: ['ADMIN'],
+        });
+      });
+      it("must set the name if it doesn't exist", async () => {
+        fakeUserPersistence.getUserByEmail.mockResolvedValueOnce({
+          id: 'fake-id',
+          roles: [{ role: 'ADMIN' }],
+        });
+
+        const actual = await sut.loadUserDetailsAndUpdateIfNecessary('joe@quizlord.net', 'Joe Blogs');
+
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.getUserByEmail).toHaveBeenCalledWith('joe@quizlord.net');
+
+        expect(fakeUserPersistence.createNewUser).not.toHaveBeenCalled();
+
+        expect(fakeUserPersistence.updateUserName).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.updateUserName).toHaveBeenCalledWith('fake-id', 'Joe Blogs');
+
+        expect(actual).toEqual({
+          id: 'fake-id',
+          roles: ['ADMIN'],
+        });
+      });
+    });
+  });
+});

--- a/src/user/user.service.test.ts
+++ b/src/user/user.service.test.ts
@@ -2,13 +2,15 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { UserPersistence } from './user.persistence';
 import { UserService } from './user.service';
+import { UserNotFoundError } from './user.errors';
 
 jest.mock('uuid');
 
 const mockedUUIDv4 = jest.mocked(uuidv4);
 const fakeUserPersistence = {
-  getUserByEmail: jest.fn(),
   createNewUser: jest.fn(),
+  getUserByEmail: jest.fn(),
+  getUserById: jest.fn(),
   updateUserName: jest.fn(),
 };
 
@@ -100,6 +102,26 @@ describe('user', () => {
         expect(actual).toEqual({
           id: 'fake-id',
           roles: ['ADMIN'],
+        });
+      });
+    });
+    describe('getUser', () => {
+      it("must throw if user doesn't exist", async () => {
+        fakeUserPersistence.getUserById.mockResolvedValueOnce(null);
+
+        await expect(() => sut.getUser('fake-id')).rejects.toThrow(UserNotFoundError);
+
+        expect(fakeUserPersistence.getUserById).toHaveBeenCalledTimes(1);
+        expect(fakeUserPersistence.getUserById).toHaveBeenCalledWith('fake-id');
+      });
+      it('must return transformed user', async () => {
+        fakeUserPersistence.getUserById.mockResolvedValueOnce({ id: 'fake-id', email: 'fake@quizlord.net' });
+
+        const actual = await sut.getUser('fake-id');
+
+        expect(actual).toEqual({
+          id: 'fake-id',
+          email: 'fake@quizlord.net',
         });
       });
     });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -10,6 +10,15 @@ export class UserService {
     this.#persistence = persistence;
   }
 
+  /**
+   * Load user details based on the provided email.
+   * If the user does not exist, create a new user.
+   * If the user's name has changed, it will be updated.
+   *
+   * @param email The email to load the user by.
+   * @param name Optionally the user's name.
+   * @returns The resulting user's roles and id.
+   */
   async loadUserDetailsAndUpdateIfNecessary(
     email: string,
     name: string | undefined,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,6 +3,7 @@ import { User as UserPersistenceModel, Role as RolePersistenceModel } from '@pri
 
 import { Role, User, UserSortOption } from './user.dto';
 import { UserPersistence } from './user.persistence';
+import { UserNotFoundError } from './user.errors';
 
 export interface GetUsersResult {
   data: User[];
@@ -105,6 +106,20 @@ export class UserService {
       data: data.map((user) => this.#userPersistenceToUser(user)),
       hasMoreRows,
     };
+  }
+
+  /**
+   * Get the user with the given id.
+   * @param userId The id to load the user for.
+   * @returns The user with the given id.
+   * @throws UserNotFoundError when no user exists with the given id.
+   */
+  async getUser(userId: string) {
+    const persistenceUser = await this.#persistence.getUserById(userId);
+    if (persistenceUser === null) {
+      throw new UserNotFoundError(`No user found with id ${userId}`);
+    }
+    return this.#userPersistenceToUser(persistenceUser);
   }
 
   #userPersistenceToUser(user: UserPersistenceModel): User {

--- a/src/util/cache.test.ts
+++ b/src/util/cache.test.ts
@@ -1,0 +1,39 @@
+import { MemoryCache } from './cache';
+
+describe('util', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+  describe('cache', () => {
+    it('must return undefined if the key does not exist', async () => {
+      const sut = new MemoryCache();
+      const actual = await sut.getItem('key');
+      expect(actual).toBeUndefined();
+    });
+    it('must return the value if the key exists', async () => {
+      const sut = new MemoryCache();
+      await sut.setItem('key', 'value', 1000);
+
+      const actual = await sut.getItem('key');
+
+      expect(actual).toBe('value');
+    });
+    it('must return undefined if the key has expired', async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2020-01-01'));
+      const sut = new MemoryCache();
+
+      await sut.setItem('key', 'value', 1000);
+      expect(await sut.getItem('key')).toBe('value');
+
+      jest.advanceTimersByTime(1001);
+      expect(await sut.getItem('key')).toBeUndefined();
+    });
+    it('must return undefined if the key has been expired manually', async () => {
+      const sut = new MemoryCache();
+      await sut.setItem('key', 'value', 1000);
+      await sut.expireItem('key');
+      expect(await sut.getItem('key')).toBeUndefined();
+    });
+  });
+});

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -20,9 +20,9 @@ export interface Cache {
    *
    * @param key The key to set the item for.
    * @param value The value to set.
-   * @param expiresInSeconds The number of seconds until the item expires.
+   * @param expiresInMillis The number of milliseconds until the item expires.
    */
-  setItem<T>(key: string, value: T, expiresInSeconds: number): Promise<void>;
+  setItem<T>(key: string, value: T, expiresInMillis: number): Promise<void>;
 
   /**
    * Manually expire an item in the cache.
@@ -45,8 +45,8 @@ export class MemoryCache implements Cache {
     }
     return Promise.resolve(record.value);
   }
-  setItem<T>(key: string, value: T, expiresInSeconds: number): Promise<void> {
-    const expiresAt = new Date(new Date().getTime() + expiresInSeconds * 1000);
+  setItem<T>(key: string, value: T, expiresInMillis: number): Promise<void> {
+    const expiresAt = new Date(new Date().getTime() + expiresInMillis);
     this.#values.set(key, {
       value,
       expiresAt,


### PR DESCRIPTION
- Adds tests to all services and utils
- Fixes an issue where statistics cache was using the wrong units for TTL
- Fixes an issue where `getUsersWithRole` was ignoring the role when the `NUMBER_OF_QUIZZES_COMPLETED_WITH_DESC` sort option was being used
- Refactors `UserService.getUsers` to be better typed using function overloading 

Out of scope (due to be less valuable and a little more tedious):

- Persistence layer
- Graphql layer