### PR TITLE
Add new resolver for marking quizzes illegible and update quiz list to allow filtering on this

### DIFF
--- a/prisma/migrations/20240622123027_quiz_notes/migration.sql
+++ b/prisma/migrations/20240622123027_quiz_notes/migration.sql
@@ -1,0 +1,19 @@
+-- CreateEnum
+CREATE TYPE "QuizNoteType" AS ENUM ('ILLEGIBLE');
+
+-- CreateTable
+CREATE TABLE "quiz_note" (
+    "id" TEXT NOT NULL,
+    "quiz_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "note_type" "QuizNoteType" NOT NULL,
+    "submitted_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "quiz_note_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "quiz_note" ADD CONSTRAINT "quiz_note_quiz_id_fkey" FOREIGN KEY ("quiz_id") REFERENCES "quiz"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "quiz_note" ADD CONSTRAINT "quiz_note_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Quiz {
 
   completions    QuizCompletion[]
   images         QuizImage[]
+  notes          QuizNote[]
   uploadedByUser User             @relation(fields: [uploadedByUserId], references: [id])
 
   @@unique(fields: [date, type])
@@ -79,6 +80,19 @@ model QuizCompletionUser {
   @@map("quiz_completion_user")
 }
 
+model QuizNote {
+  id          String       @id
+  quizId      String       @map("quiz_id")
+  userId      String       @map("user_id")
+  noteType    QuizNoteType @map("note_type")
+  submittedAt DateTime     @map("submitted_at")
+
+  quiz Quiz @relation(fields: [quizId], references: [id])
+  user User @relation(fields: [userId], references: [id])
+
+  @@map("quiz_note")
+}
+
 model User {
   id    String  @id
   email String
@@ -86,9 +100,14 @@ model User {
 
   roles           UserRole[]
   quizCompletions QuizCompletionUser[]
+  quizNotes       QuizNote[]
   uploadedQuizzes Quiz[]
 
   @@map("user")
+}
+
+enum QuizNoteType {
+  ILLEGIBLE
 }
 
 enum Role {

--- a/src/gql.ts
+++ b/src/gql.ts
@@ -128,6 +128,17 @@ const typeDefs = gql`
     averageScorePercentage: Float!
   }
 
+  enum ExcludeIllegibleOptions {
+    """
+    Exclude quizzes that have been marked as illegible by me.
+    """
+    ME
+    """
+    Exclude quizzes that have been marked as illegible by anyone.
+    """
+    ANYONE
+  }
+
   "Available filters for the quizzes query"
   input QuizFilters {
     """
@@ -135,6 +146,10 @@ const typeDefs = gql`
     If provided, only quizzes completed by none of these users will be included in the results.
     """
     excludeCompletedBy: [String]
+    """
+    Optional option to exclude quizzes that have been marked as illegible.
+    """
+    excludeIllegible: ExcludeIllegibleOptions
   }
 
   type Query {

--- a/src/gql.ts
+++ b/src/gql.ts
@@ -186,6 +186,7 @@ const typeDefs = gql`
   type Mutation {
     createQuiz(type: QuizType!, date: Date!, files: [CreateQuizFile]): CreateQuizResult
     completeQuiz(quizId: String!, completedBy: [String]!, score: Float!): CompleteQuizResult
+    markQuizIllegible(quizId: String!): Boolean
   }
 `;
 

--- a/src/quiz/quiz.dto.ts
+++ b/src/quiz/quiz.dto.ts
@@ -37,6 +37,7 @@ export interface QuizDetails {
 
 export interface QuizFilters {
   excludeCompletedBy?: string[];
+  excludeIllegible?: 'ME' | 'ANYONE';
 }
 
 export interface CreateQuizResult {

--- a/src/quiz/quiz.gql.ts
+++ b/src/quiz/quiz.gql.ts
@@ -58,6 +58,16 @@ async function completeQuiz(
   });
 }
 
+async function markQuizIllegible(
+  _: unknown,
+  { quizId }: { quizId: string },
+  context: QuizlordContext,
+): Promise<boolean> {
+  authorisationService.requireUserRole(context, 'USER');
+  quizService.markQuizIllegible(quizId, context.email);
+  return true;
+}
+
 export const quizQueries = {
   quizzes,
   quiz,
@@ -65,4 +75,5 @@ export const quizQueries = {
 export const quizMutations = {
   createQuiz,
   completeQuiz,
+  markQuizIllegible,
 };

--- a/src/quiz/quiz.persistence.ts
+++ b/src/quiz/quiz.persistence.ts
@@ -70,6 +70,23 @@ export class QuizPersistence {
             },
           },
         }),
+        ...(filters.excludeIllegible === 'ME' && {
+          notes: {
+            none: {
+              noteType: 'ILLEGIBLE',
+              user: {
+                email: userEmail,
+              },
+            },
+          },
+        }),
+        ...(filters.excludeIllegible === 'ANYONE' && {
+          notes: {
+            none: {
+              noteType: 'ILLEGIBLE',
+            },
+          },
+        }),
       },
     });
 

--- a/src/quiz/quiz.persistence.ts
+++ b/src/quiz/quiz.persistence.ts
@@ -1,4 +1,5 @@
-import { Quiz, QuizImage } from '@prisma/client';
+import { Quiz, QuizImage, QuizNoteType } from '@prisma/client';
+import { v4 as uuidv4 } from 'uuid';
 
 import { PrismaService } from '../database/prisma.service';
 import { QuizFilters } from './quiz.dto';
@@ -221,5 +222,38 @@ export class QuizPersistence {
       },
     });
     return slicePagedResults(result, limit, afterId !== undefined);
+  }
+
+  async addQuizNote({
+    quizId,
+    noteType,
+    userEmail,
+    submittedAt,
+  }: {
+    quizId: string;
+    noteType: QuizNoteType;
+    userEmail: string;
+    submittedAt: Date;
+  }) {
+    const user = await this.#prisma.client().user.findFirst({
+      where: {
+        email: userEmail,
+      },
+    });
+
+    if (!user) {
+      throw new Error(`Unable to find user with email ${userEmail}`);
+    }
+
+    const noteId = uuidv4();
+    await this.#prisma.client().quizNote.create({
+      data: {
+        id: noteId,
+        noteType,
+        quizId,
+        userId: user.id,
+        submittedAt,
+      },
+    });
   }
 }

--- a/src/quiz/quiz.service.ts
+++ b/src/quiz/quiz.service.ts
@@ -276,4 +276,12 @@ export class QuizService {
       },
     };
   }
+  async markQuizIllegible(quizId: string, userEmail: string): Promise<void> {
+    await this.#persistence.addQuizNote({
+      quizId,
+      noteType: 'ILLEGIBLE',
+      submittedAt: new Date(),
+      userEmail,
+    });
+  }
 }


### PR DESCRIPTION
Introduces the ideas of "Quiz Notes". At the moment this includes only marking quizzes as illegible but the same table will be used later to request corrects etc.

Adds a new resolver `markQuizIllegible` which adds a note against the given quiz. Also tracks the user that added the note and the time they added it.

Adds a new filter when listing quizzes `excludeIllegible` which either allows you to exclude quizzes that **you** have marked illegible or quizzes that anyone has marked illegible.

Currently does not surface the quiz notes anywhere but will likely later be surfaced as part of the quiz details resolver.