### PR TITLE
Fix deployment issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 FROM node:22.13.0-alpine
+
+# Since alpine 3.21 the location of openssl has moved. This is a workaround to allow prisma access
+# openssl at it's previous location. It should be able to be removed once prisma is updated.
+# See https://github.com/prisma/prisma/issues/25817 for details.
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
+
 ENV NODE_ENV=production
 
 ARG IMAGE_VERSION

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ npm run build
 # Build a local image tagged with local
 docker build -t quizlord-api:local .
 # Run local build using the env file
-docker run -p 4000:80 --env-file <(doppler secrets download --no-file --format docker) -e QUIZLORD_VERSION=local --name=quizlord-api quizlord-api:local
+docker run -p 4000:80 --rm --env-file <(doppler secrets download --no-file --format docker) -e QUIZLORD_VERSION=local --name=quizlord-api quizlord-api:local
 # Cleanup
-docker rm quizlord-api && docker image rm quizlord-api:local
+docker image rm quizlord-api:local
 ```
 
 ## Test Helm Locally

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm run build
 # Build a local image tagged with local
 docker build -t quizlord-api:local .
 # Run local build using the env file
-docker run -p 4000:80 --env-file <(doppler secrets download --no-file --format docker) --name=quizlord-api quizlord-api:local
+docker run -p 4000:80 --env-file <(doppler secrets download --no-file --format docker) -e QUIZLORD_VERSION=local --name=quizlord-api quizlord-api:local
 # Cleanup
 docker rm quizlord-api && docker image rm quizlord-api:local
 ```


### PR DESCRIPTION
- **Add missing QUIZLORD_VERSION environment variable to local docker instructions**
- **Simplify local docker running instructions with `--rm`**
- **Update Dockerfile to add workaround for prisma openssl**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Dockerfile with a symbolic link to resolve OpenSSL compatibility on Alpine Linux.
	- Modified README.md Docker testing instructions to include `--rm` flag and `QUIZLORD_VERSION=local` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->