### PR TITLE
Fix bugs with AI processing

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           resources:
             limits:
               cpu: 50m
-              memory: 80Mi
+              memory: 120Mi
           ports:
             - name: http-web
               containerPort: 80

--- a/src/queue/sqs-listener.service.ts
+++ b/src/queue/sqs-listener.service.ts
@@ -103,6 +103,12 @@ export class SQSQueueListenerService {
       if (messageBody.quizId) {
         try {
           await this.#quizService.aiProcessQuiz(messageBody.quizId);
+          await this.#client.send(
+            new DeleteMessageCommand({
+              QueueUrl: config.AWS_AI_PROCESSING_SQS_QUEUE_URL,
+              ReceiptHandle: message.ReceiptHandle,
+            }),
+          );
         } catch (err) {
           console.error(`Error processing quiz id: ${messageBody.quizId}`, err);
         }
@@ -110,12 +116,5 @@ export class SQSQueueListenerService {
         console.warn(`Unexpected message body`, message);
       }
     }
-
-    await this.#client.send(
-      new DeleteMessageCommand({
-        QueueUrl: config.AWS_AI_PROCESSING_SQS_QUEUE_URL,
-        ReceiptHandle: message.ReceiptHandle,
-      }),
-    );
   }
 }


### PR DESCRIPTION
Increase memory limit to account for gemini's increased usage
80Mi -> 120Mi (just guessing)

In the private infra repo the processing queue was modified so that failed AI processing is only retried once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Increased the container's memory limit to enhance performance and better support workload demands.
- **Bug Fixes**
  - Improved message deletion logic in the SQS queue to ensure messages are only removed after successful processing attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->