### PR TITLE
Add a new linting rule to prevent floating promises

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,8 +3,15 @@ const config = require('@dtdot/eslint-config');
 module.exports = [
   ...config.eslint.configs.recommended,
   {
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+      },
+    },
     rules: {
-      // Place any rule overrides in here
+      // Overriding/updating/adding rules over the base provided by @dtdot/eslint-config
+      '@typescript-eslint/no-floating-promises': 'error',
     }
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,8 +128,8 @@ async function initialise() {
     }),
   );
 
-  queueService.subscribeToFileUploads();
-  queueService.subscribeToAiProcessing();
+  void queueService.subscribeToFileUploads();
+  void queueService.subscribeToAiProcessing();
   await new Promise<void>((resolve) => httpServer.listen({ port: 4000 }, resolve));
 
   console.log(`🚀 Server ready at http://localhost:4000/`);


### PR DESCRIPTION
In the two places they are using them on purpose mark them as void so
the linting rule does not fire.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code clarity by explicitly marking certain asynchronous operations as intentionally not awaited.

* **Chores**
  * Updated linting configuration to enforce stricter promise handling and clarified configuration comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->