### PR TITLE
Updated bump-node-version skill

### DIFF
--- a/.claude/skills/bump-node-version/SKILL.md
+++ b/.claude/skills/bump-node-version/SKILL.md
@@ -25,11 +25,21 @@ If this fails (e.g. nvm is not found at that path), ask the user to run `nvm ins
 
 Read `.nvmrc` to get the current (old) version string. You'll need this to search for occurrences to replace.
 
-### 3. Update `.nvmrc`
+### 3. Verify the Docker image exists
+
+Before making any changes, confirm the corresponding Docker image is available on Docker Hub. Check by fetching:
+
+```
+https://hub.docker.com/v2/repositories/library/node/tags?name=<NEW_VERSION>-alpine
+```
+
+Look for a tag matching `<NEW_VERSION>-alpine` (e.g. `24.13.1-alpine`). If the image does not exist yet, **stop and inform the user** — the node version bump cannot proceed until the Docker image is published.
+
+### 4. Update `.nvmrc`
 
 Run `node --version > .nvmrc` and verify the diff shows the expected version change.
 
-### 4. Search for the old version
+### 5. Search for the old version
 
 Search the entire codebase for the old version number (without the `v` prefix, e.g. `24.13.0`). Typical locations include:
 
@@ -38,13 +48,13 @@ Search the entire codebase for the old version number (without the `v` prefix, e
 - `package-lock.json` — `engines.node` field
 - `.github/workflows/*.yml` / `.yaml` — `NODE_VERSION` env var
 
-### 5. Spot-check and replace
+### 6. Spot-check and replace
 
 Review each occurrence to confirm it is actually a Node.js version reference and not an unrelated package version. Then update each one to the new version.
 
 **Do not use a blind find-and-replace.** Inspect each match individually.
 
-### 6. Update node-related packages
+### 7. Update node-related packages
 
 First run `npm ci` to ensure `node_modules` is up to date with the lockfile before checking for outdated packages.
 
@@ -55,7 +65,7 @@ Then run `npm outdated` **without any package name filters** and scan the full o
 
 Update these with `npm update <package>`.
 
-### 7. Validate
+### 8. Validate
 
 Run the following commands in sequence and confirm each passes:
 
@@ -65,7 +75,7 @@ Run the following commands in sequence and confirm each passes:
 
 If any step fails, investigate and fix before proceeding.
 
-### 8. Prepare the commit
+### 9. Prepare the commit
 
 Use the `commit-message-guidelines` skill to write a commit message in the format:
 


### PR DESCRIPTION
Added Docker Hub image availability check before making
changes, to prevent broken builds when the alpine image
hasn't been published yet.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node version bump workflow to include Docker image verification step before proceeding with version updates.
  * Reorganized process steps with improved guidance and updated numbering for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->