### PR TITLE
Pinned Renovate auto-merge to merge commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,12 @@
   "labels": ["semver:patch"],
   "packageRules": [
     {
-      "description": "Auto-merge patch and minor updates after a 7-day soak; major updates stay manual. platformAutomerge uses GitHub's native auto-merge, so each PR merges only once the required branch-protection checks pass and only Renovate's own PRs are affected.",
+      "description": "Auto-merge patch and minor updates after a 7-day soak; major updates stay manual. platformAutomerge uses GitHub's native auto-merge, so each PR merges only once the required branch-protection checks pass and only Renovate's own PRs are affected. automergeStrategy is pinned to 'merge' because the main ruleset only permits merge commits; GitHub rejects arming auto-merge if Renovate requests a disallowed strategy.",
       "matchUpdateTypes": ["patch", "minor"],
       "minimumReleaseAge": "7 days",
       "automerge": true,
-      "platformAutomerge": true
+      "platformAutomerge": true,
+      "automergeStrategy": "merge"
     }
   ]
 }


### PR DESCRIPTION
Set automergeStrategy to "merge" on the auto-merge rule. The main
ruleset only permits merge commits, and GitHub refuses to arm native
auto-merge when Renovate requests a disallowed strategy, which left
autoMergeRequest null on every PR despite the "Automerge: Enabled"
badge.

Co-Authored-By: Claude <noreply@anthropic.com>
