### PR TITLE
Restored v prefix on published docker image tags

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -109,7 +109,11 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.version }}
+          # Tag with the v-prefixed `tag` (e.g. v1.3.0-rc.0), not bare `version`: the helm chart and
+          # operators pin `api.version` to a vX.Y.Z string (CONTRIBUTING "Operator rules"), so the
+          # published image tag must carry the v. (The bare `version`/`base-version` are still used
+          # for the runtime/Sentry version below.)
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.tag }}
           build-args: |
             IMAGE_VERSION=${{ needs.version.outputs.base-version }}
 

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -72,12 +72,11 @@ jobs:
       - name: Retag prerelease image as stable
         env:
           RC_TAG: ${{ inputs.prerelease_version }}
-          STABLE: ${{ needs.pre_release.outputs.release-version }}
+          STABLE_TAG: ${{ needs.pre_release.outputs.release-tag }}
         run: |
-          RC="${RC_TAG#v}"
           docker buildx imagetools create \
-            --tag "${REGISTRY}/${IMAGE_NAME}:${STABLE}" \
-            "${REGISTRY}/${IMAGE_NAME}:${RC}"
+            --tag "${REGISTRY}/${IMAGE_NAME}:${STABLE_TAG}" \
+            "${REGISTRY}/${IMAGE_NAME}:${RC_TAG}"
 
   helm-stable:
     needs: pre_release
@@ -159,11 +158,11 @@ jobs:
 
       - name: Point latest at the stable image
         env:
-          STABLE: ${{ needs.pre_release.outputs.release-version }}
+          STABLE_TAG: ${{ needs.pre_release.outputs.release-tag }}
         run: |
           docker buildx imagetools create \
             --tag "${REGISTRY}/${IMAGE_NAME}:latest" \
-            "${REGISTRY}/${IMAGE_NAME}:${STABLE}"
+            "${REGISTRY}/${IMAGE_NAME}:${STABLE_TAG}"
 
   post_release:
     needs:


### PR DESCRIPTION
The versioning rework switched the published image tag from the
v-prefixed git tag to the bare semver version, but the helm chart and
operators still pin api.version to a vX.Y.Z string (CONTRIBUTING
"Operator rules"), so deploys would hit ImagePullBackOff.

Tag the rc image from the v-prefixed `tag` output, and retag the stable
and latest images from the v-prefixed `release-tag` (dropping the prefix
strip), matching the pre-rework behaviour. Chart version, appVersion and
the Sentry release stay bare semver as before.

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docker image tagging so release-candidate builds are published with the expected `vX.Y.Z-rc.N` tag format.
  * Improved stable and `latest` image promotion to use the correct release tag, helping ensure downstream systems pull the intended artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->