### PR TITLE
Wired helm-supplied version into the running app

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -165,11 +165,12 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
-          # Key the release on the FULL rc version (not base-version): the staging runtime sets
-          # QUIZLORD_VERSION to the full rc (C2), and sourcemaps resolve only on an exact release-name
-          # match (the bundle carries no debug IDs). Promotion re-uploads these maps under the stable
-          # version so prod resolves too — see release-stable.yml.
-          release: ${{ needs.version.outputs.version }}
+          # Key the release on the full v-prefixed rc tag. The helm chart sets QUIZLORD_VERSION from
+          # api.version, so the staging deploy (pinned to this rc tag) reports the exact same string at
+          # runtime — and sourcemaps resolve only on an exact release-name match (the bundle carries no
+          # debug IDs). Promotion re-uploads these maps under the stable tag so prod resolves too — see
+          # release-stable.yml.
+          release: ${{ needs.version.outputs.tag }}
           environment: stg
           sourcemaps: ./dist
           url_prefix: '/app'

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -106,9 +106,10 @@ jobs:
     needs: pre_release
     runs-on: ubuntu-latest
     steps:
-      # The staging Sentry release is keyed on the full rc version, but prod reports the bare stable
-      # QUIZLORD_VERSION (the image bakes base-version, C1). Sourcemaps resolve only on an exact
-      # release-name match, so re-upload the rc's persisted sourcemaps under the stable release.
+      # The rc Sentry release is keyed on the rc tag, but prod runs the promoted image with
+      # QUIZLORD_VERSION set from api.version (the stable vX.Y.Z tag), which differs from that rc tag.
+      # Sourcemaps resolve only on an exact release-name match, so re-upload the rc's persisted
+      # sourcemaps under the stable release tag.
       - name: Download rc sourcemaps
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,7 +128,7 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
-          release: ${{ needs.pre_release.outputs.release-version }}
+          release: ${{ needs.pre_release.outputs.release-tag }}
           environment: prod
           sourcemaps: ./dist
           url_prefix: '/app'

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - name: http-web
               containerPort: 80
           env:
-            - name: API_VERSION
+            - name: QUIZLORD_VERSION
               value: {{ .Values.api.version | quote }}
           envFrom:
             - secretRef:

--- a/helm/templates/migration.yaml
+++ b/helm/templates/migration.yaml
@@ -14,7 +14,7 @@ spec:
               cpu: 100m
               memory: 256Mi
           env:
-            - name: API_VERSION
+            - name: QUIZLORD_VERSION
               value: {{ .Values.api.version | quote }}
           envFrom:
             - secretRef:


### PR DESCRIPTION
The app reads QUIZLORD_VERSION, but the helm chart set an API_VERSION env
that nothing in src has ever read, so the deployed api.version never
reached the runtime UI header or Sentry release name. Those came only
from the bare base-version baked at build time, dropping the v prefix
prod used to show and leaving rc sourcemaps unresolvable.

Rename the env to QUIZLORD_VERSION in both templates so the
terraform-supplied (v-prefixed) api.version drives the runtime version,
and key both Sentry releases on the v-prefixed tags (rc -> tag, stable
-> release-tag) so the CI release name matches what the app reports.

Co-Authored-By: Claude <noreply@anthropic.com>
