### PR TITLE
Grouped Renovate Node.js version bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,21 @@
       "automerge": true,
       "platformAutomerge": true,
       "automergeStrategy": "merge"
+    },
+    {
+      "description": "Group all Node.js version bumps into a single PR so .nvmrc, the Dockerfile base image, engines.node, @types/node, @tsconfig/nodeXX, and the NODE_VERSION env var in GitHub Actions workflows (via customManagers below) stay in sync. The 'node' dep name covers the nvm, dockerfile, npm (engines), and custom regex managers.",
+      "matchPackageNames": ["node", "@types/node", "/^@tsconfig/node/"],
+      "groupName": "node"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Treat the NODE_VERSION env var in GitHub Actions workflows as a node dependency so Renovate can bump it alongside .nvmrc, Dockerfile, and engines.node.",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": ["NODE_VERSION:\\s*['\"]?(?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]?"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version"
     }
   ]
 }


### PR DESCRIPTION
Added a packageRules entry that groups the `node` dep (covering
.nvmrc, the Dockerfile base image, and engines.node), `@types/node`,
and `@tsconfig/nodeXX` into a single PR so they stay in sync.

Added a customManagers regex entry that detects the NODE_VERSION
env var in .github/workflows/*.yml as the `node` dep, so the CI
runner version is bumped alongside the rest instead of drifting
(currently .nvmrc is at 24.17.0 while workflows are at 24.16.0).

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling by grouping Node-related updates into a single change request.
  * Added support for detecting Node version values in workflow files, so they can be updated automatically alongside other Node dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->